### PR TITLE
Change python in docker and replace deprecated setLogLevel

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -6,8 +6,9 @@ RUN apt-get update --fix-missing \
 
 # DEPENDENCIES
 RUN apt-get update --fix-missing \
-    && apt-get install -y  python \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get install -y python3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && ln -s /usr/bin/python3 /usr/bin/python
 
 # KAFKA
 RUN git clone --depth 1 --branch v0.11.1 https://github.com/edenhill/librdkafka.git \

--- a/public/consumer.php
+++ b/public/consumer.php
@@ -1,7 +1,9 @@
 <?php
 
-$consumer = new \RdKafka\Consumer();
-$consumer->setLogLevel(LOG_DEBUG);
+$conf = new RdKafka\Conf();
+$conf->set('log_level', (string) LOG_DEBUG);
+$consumer = new \RdKafka\Consumer($conf);
+
 $consumer->addBrokers("kafka:9092");
 
 $topic = $consumer->newTopic("test");

--- a/public/index.php
+++ b/public/index.php
@@ -1,7 +1,8 @@
 <?php
 
-$producer = new \RdKafka\Producer();
-$producer->setLogLevel(LOG_DEBUG);
+$conf = new RdKafka\Conf();
+$conf->set('log_level', (string) LOG_DEBUG);
+$producer = new \RdKafka\Producer($conf);
 
 if ($producer->addBrokers("kafka:9092") < 1) {
     echo "Failed adding brokers\n";


### PR DESCRIPTION
Hi Phillaf,

Since the php:8.2-fpm docker image has changed, the python is not part of the image, though python3 is available.
This pull request updates the Dockerfile to respect that and also creates a symbolic link to make it backward compatible

The setLogLevel function also got deprecated, and replacing with config.
